### PR TITLE
docs(#5): normalize operator naming in docs and runtime output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,4 @@
 
 No mandatory post-reply mirroring is required.
 
-For agent message delivery, use relay-core HTTP endpoints (`/v1/agent/send`) from the runtime workflow.
+For agent message delivery, use operator HTTP endpoints (`/v1/agent/send`) from the runtime workflow.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ```mermaid
 flowchart LR
-    M[Matrix Homeserver] -->|/sync events| R[relay-core runtime]
+    M[Matrix Homeserver] -->|/sync events| R[operator runtime]
     R -->|enqueue user envelope| U[(Redis: project:user)]
 
     U -->|BLPOP| W[auto-opencode worker]
@@ -63,7 +63,7 @@ Authentication for `/v1/agent/*` is Bearer token based (`agentApiToken`/`agentAp
 - `src/runtime/redis.ts`: Redis connectivity, queue key naming, envelope encode/decode.
 - `src/runtime/matrix.ts`: Matrix API client helpers and event/content transformations.
 - `src/runtime/loops.ts`: inbound `/sync` ingestion and outbound queue-to-Matrix delivery loops.
-- `src/runtime/http.ts`: relay-core HTTP facade for health, metrics, and external agent APIs.
+- `src/runtime/http.ts`: operator HTTP facade for health, metrics, and external agent APIs.
 - `src/worker/auto-opencode.ts`: per-project worker + supervisor lifecycle.
 - `src/runtime/process.ts`: process execution and OpenCode stream handling.
 - `src/worker/context-state.ts`: rolling context files used to build each OpenCode prompt.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Architecture reference: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 
 ```mermaid
 flowchart LR
-    A[Matrix Room] -->|messages| B[operator<br/>relay-core]
+    A[Matrix Room] -->|messages| B[operator runtime]
     B -->|queue| C[Redis Queue]
     B -->|spawn| D[OpenCode]
     
@@ -219,6 +219,10 @@ bun run src/index.ts poll-user my-project --block 30
 - **Message Format**: Outbound messages support Markdown, converted to Matrix HTML
 - **Security**: `command` runs with the process's permissions - treat as privileged config
 - **Legacy**: `autoCodex*` and `autoOpenCode*` config keys are no longer supported
+
+## Naming
+
+The canonical public project name is `operator`. Older references to `matrix-relay-core` have been normalized to `operator` in docs and runtime output.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -674,7 +674,7 @@ function markAndCheckDuplicate(
 }
 
 function printUsage() {
-  console.log(`matrix-relay-core
+  console.log(`operator
 
 Commands:
   daemon (default)
@@ -712,7 +712,7 @@ Project-level config (all projects run the interactive agent):
   senderAllowlist: ["@admin:your-server"]              # required
   progressUpdates: true                                # default true
   stateDir: ".operator-state"                          # default
-  projectWorkingDirectory: "/abs/path/to/project"      # default: current relay-core cwd
+  projectWorkingDirectory: "/abs/path/to/project"      # default: current operator cwd
   model: "opencode/minimax-m2.5-free"                  # optional per-project model override
   ackTemplate: "Starting OpenCode {{job_id}}."         # used when verbosity=debug
   progressTemplate: "OpenCode {{phase}} ({{job_id}})." # used for debug status updates

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -7,7 +7,7 @@ Responsibility split:
 - `src/runtime/config.ts`: config schema/types, token/admin parsing, config persistence/loading, project lookup, room/project mapping.
 - `src/runtime/redis.ts`: Redis connectivity, queue keying, queue envelope encode/decode.
 - `src/runtime/matrix.ts`: Matrix HTTP client helpers, message rendering, room join/sync primitives, timeline-to-queue conversion.
-- `src/runtime/http.ts`: relay-core HTTP facade (`/health`, `/v1/metrics`, `/v1/agent/*`) with auth and payload validation.
+- `src/runtime/http.ts`: operator HTTP facade (`/health`, `/v1/metrics`, `/v1/agent/*`) with auth and payload validation.
 - `src/runtime/loops.ts`: inbound/outbound Matrix-Redis worker loops and event routing glue.
 - `src/runtime/process.ts`: command process execution, OpenCode run command preparation, and stream-to-output parsing.
 - `src/worker/auto-opencode.ts`: auto-opencode project worker and supervisor loop implementations.

--- a/src/runtime/http.ts
+++ b/src/runtime/http.ts
@@ -280,7 +280,7 @@ export async function startHttpFacade(
       );
       return json(200, {
         ok: true,
-        service: "matrix-relay-core",
+        service: "operator",
         generatedAt: new Date().toISOString(),
         queueDepth,
         ...buildMetricsSnapshot(),
@@ -305,7 +305,7 @@ export async function startHttpFacade(
       if ((path === "/health" || path === "/v1/health") && method === "GET") {
         return json(200, {
           ok: true,
-          service: "matrix-relay-core",
+          service: "operator",
           authConfigured: authTokens.size > 0,
         });
       }


### PR DESCRIPTION
## Summary
- Set `operator` as the canonical public name across top-level docs and runtime module docs.
- Updated CLI/runtime user-facing output to remove legacy `matrix-relay-core` labels (`src/index.ts` usage banner and HTTP `service` field values).
- Added a short naming note in `README.md` documenting the normalization.

## Why
Issue #5 calls out naming drift that creates onboarding confusion. This aligns docs and visible runtime output around one consistent project identity.

## Risk / Rollback
- Low risk: text and metadata-only changes, no behavior or queue contract changes.
- Roll back by reverting this PR if any downstream tooling depends on the old `service` label.

## Verification
- `bunx tsc --noEmit`
- `bun test`

Closes #5