### PR TITLE
refactor(#9): centralize queue and HTTP payload contracts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,10 @@ import {
   parseEnvelope,
   queueKey,
   resolveRedisConfig,
-  type QueueDirection,
-  type QueueEnvelope,
   type Redis,
   type RedisConfig,
 } from "./runtime/redis";
+import { type QueueDirection, type QueueEnvelope } from "./types/contracts";
 import {
   buildMatrixContent,
   fetchBotUserId,

--- a/src/runtime/http.ts
+++ b/src/runtime/http.ts
@@ -6,12 +6,14 @@ import {
 } from "../metrics";
 import { nonEmptyText, parseFormat, parseOptionalString, type MessageFormat } from "../text";
 import { type ProjectConfig } from "./config";
+import { type Redis } from "./redis";
 import {
+  type AgentPollRequestPayload,
+  type AgentSendRequestPayload,
   type QueueDirection,
   type QueueEnvelope,
-  type Redis,
-  type QueueEnvelope as Envelope,
-} from "./redis";
+  type QueueEnvelopeExtras,
+} from "../types/contracts";
 
 type JsonObject = Record<string, unknown>;
 
@@ -44,8 +46,8 @@ type HttpFacadeDependencies = {
     roomId: string,
     body: string,
     format: MessageFormat,
-    extras: { agent?: string; sender?: string },
-  ) => Envelope;
+    extras: QueueEnvelopeExtras,
+  ) => QueueEnvelope;
 };
 
 function json(status: number, payload: unknown): Response {
@@ -118,7 +120,7 @@ function authorizeAgentRequest(req: Request, tokens: Set<string>): Response | nu
   return null;
 }
 
-function parseProjectKeyFromPayload(payload: JsonObject): string {
+function parseProjectKeyFromPayload(payload: AgentPollRequestPayload | AgentSendRequestPayload): string {
   const projectKey = nonEmptyText(payload.project) ?? nonEmptyText(payload.project_key);
   if (!projectKey) {
     throw new Error("missing project (or project_key)");
@@ -126,7 +128,7 @@ function parseProjectKeyFromPayload(payload: JsonObject): string {
   return projectKey;
 }
 
-function parseAgentPollRequest(payload: JsonObject): AgentPollRequest {
+function parseAgentPollRequest(payload: AgentPollRequestPayload): AgentPollRequest {
   const agent = parseOptionalString(payload.agent);
   const blockSeconds = parseBlockSeconds(payload.block_seconds, 30);
 
@@ -137,7 +139,7 @@ function parseAgentPollRequest(payload: JsonObject): AgentPollRequest {
   };
 }
 
-function parseAgentSendRequest(payload: JsonObject): AgentSendRequest {
+function parseAgentSendRequest(payload: AgentSendRequestPayload): AgentSendRequest {
   const markdown = nonEmptyText(payload.markdown);
   const body =
     nonEmptyText(payload.body) ??
@@ -176,7 +178,7 @@ export async function startHttpFacade(
     let parsed: AgentPollRequest;
     try {
       const payload = await parseJsonObject(req);
-      parsed = parseAgentPollRequest(payload);
+      parsed = parseAgentPollRequest(payload as AgentPollRequestPayload);
     } catch (error: unknown) {
       const detail = error instanceof Error ? error.message : String(error);
       return json(400, { error: detail });
@@ -229,7 +231,7 @@ export async function startHttpFacade(
     let parsed: AgentSendRequest;
     try {
       const payload = await parseJsonObject(req);
-      parsed = parseAgentSendRequest(payload);
+      parsed = parseAgentSendRequest(payload as AgentSendRequestPayload);
     } catch (error: unknown) {
       const detail = error instanceof Error ? error.message : String(error);
       return json(400, { error: detail });

--- a/src/runtime/loops.ts
+++ b/src/runtime/loops.ts
@@ -9,7 +9,8 @@ import {
   type MatrixClientConfig,
   type MatrixTimelineEvent,
 } from "./matrix";
-import { type QueueDirection, type QueueEnvelope, type Redis } from "./redis";
+import { type Redis } from "./redis";
+import { type QueueDirection, type QueueEnvelope } from "../types/contracts";
 
 export type RunOutboundLoopOptions = {
   outboundRedis: Redis;

--- a/src/runtime/matrix.ts
+++ b/src/runtime/matrix.ts
@@ -1,6 +1,6 @@
 import { marked } from "marked";
 import { nonEmptyText, type MessageFormat } from "../text";
-import { type QueueEnvelope } from "./redis";
+import { type QueueEnvelope } from "../types/contracts";
 
 export type MatrixClientConfig = {
   homeserverUrl: string;

--- a/src/runtime/redis.ts
+++ b/src/runtime/redis.ts
@@ -1,18 +1,12 @@
 import { RedisClient } from "bun";
 import { nonEmptyText, parseFormat, parseOptionalString, type MessageFormat } from "../text";
+import {
+  type QueueDirection,
+  type QueueEnvelope,
+  type QueueEnvelopeExtras,
+} from "../types/contracts";
 
-export type QueueDirection = "agent" | "user";
-
-export type QueueEnvelope = {
-  id: string;
-  projectKey: string;
-  roomId: string;
-  body: string;
-  format: MessageFormat;
-  agent?: string;
-  sender?: string;
-  receivedAt: string;
-};
+export type { QueueDirection, QueueEnvelope } from "../types/contracts";
 
 export type Redis = RedisClient;
 
@@ -126,7 +120,7 @@ export function createEnvelope(
   roomId: string,
   body: string,
   format: MessageFormat,
-  extras: { agent?: string; sender?: string },
+  extras: QueueEnvelopeExtras,
 ): QueueEnvelope {
   return {
     id: crypto.randomUUID(),

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -1,0 +1,37 @@
+import { type MessageFormat } from "../text";
+
+export type QueueDirection = "agent" | "user";
+
+export type QueueEnvelope = {
+  id: string;
+  projectKey: string;
+  roomId: string;
+  body: string;
+  format: MessageFormat;
+  agent?: string;
+  sender?: string;
+  receivedAt: string;
+};
+
+export type QueueEnvelopeExtras = {
+  agent?: string;
+  sender?: string;
+};
+
+export type AgentPollRequestPayload = {
+  project?: string;
+  project_key?: string;
+  agent?: string;
+  block_seconds?: number | string;
+};
+
+export type AgentSendRequestPayload = {
+  project?: string;
+  project_key?: string;
+  markdown?: string;
+  body?: string;
+  message?: string;
+  text?: string;
+  format?: string;
+  agent?: string;
+};

--- a/src/worker/auto-opencode.ts
+++ b/src/worker/auto-opencode.ts
@@ -1,7 +1,8 @@
 import { appendStreamText, formatThinkingStreamDelta } from "../opencode-stream";
 import { logEvent, recordFailure, recordProcessingLatency, recordWorkerRestart } from "../metrics";
 import { type MessageFormat, truncateInline, truncateText } from "../text";
-import { type QueueDirection, type QueueEnvelope, type Redis, type RedisConfig } from "../runtime/redis";
+import { type Redis, type RedisConfig } from "../runtime/redis";
+import { type QueueDirection, type QueueEnvelope } from "../types/contracts";
 
 export type AutoOpenCodeVerbosity = "debug" | "thinking" | "thinking-complete" | "output";
 

--- a/src/worker/context-state.ts
+++ b/src/worker/context-state.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tailLines, truncateText } from "../text";
-import { type QueueEnvelope } from "../runtime/redis";
+import { type QueueEnvelope } from "../types/contracts";
 import { type AutoOpenCodeProject } from "./auto-opencode";
 
 export type AutoOpenCodeStatePaths = {


### PR DESCRIPTION
## Summary
- Added `src/types/contracts.ts` as a shared home for queue and API payload contracts.
- Moved `QueueDirection`/`QueueEnvelope` types out of runtime modules and updated imports across runtime/worker entry points.
- Updated HTTP facade request parsing to use explicit payload contract types instead of ad hoc object shapes.

## Why
Issue #9 asks for centralized, strongly typed contracts so contributors can modify queue/API boundaries safely without duplicated local type shapes.

## Risk / Rollback
- Low risk: type-only refactor and import rewiring; no behavior or protocol changes.
- Rollback by reverting this PR.

## Verification
- `bunx tsc --noEmit`
- `bun test`

Closes #9