### PR TITLE
test(#11): expand boundary coverage for config, routing, queue, and process

### DIFF
--- a/src/commands/management.test.ts
+++ b/src/commands/management.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parseManagementCommandArgs } from "./management";
+
+describe("parseManagementCommandArgs", () => {
+  test("parses create command with required options", () => {
+    const parsed = parseManagementCommandArgs([
+      "create",
+      "operator",
+      "--room",
+      "!room:example.org",
+      "--path",
+      "/repo",
+    ]);
+
+    expect(parsed).toEqual({
+      action: "create",
+      projectKey: "operator",
+      roomId: "!room:example.org",
+      projectWorkingDirectory: "/repo",
+    });
+  });
+
+  test("parses show and delete actions", () => {
+    expect(parseManagementCommandArgs(["show", "operator"])).toEqual({
+      action: "show",
+      projectKey: "operator",
+    });
+
+    expect(parseManagementCommandArgs(["delete", "operator"])).toEqual({
+      action: "delete",
+      projectKey: "operator",
+    });
+  });
+
+  test("rejects create command without required options", () => {
+    expect(() => parseManagementCommandArgs(["create", "operator", "--room", "!room:example.org"])).toThrow(
+      "project create requires --path <directory>",
+    );
+  });
+});

--- a/src/runtime/config.test.ts
+++ b/src/runtime/config.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildRoomToProjectMap,
+  parseAdminUserIds,
+  parseAgentApiTokens,
+  resolveProject,
+  type AppConfig,
+} from "./config";
+
+const BASE_CONFIG: AppConfig = {
+  homeserverUrl: "https://matrix.example.org",
+  accessToken: "token",
+  projects: {},
+};
+
+describe("runtime/config", () => {
+  test("parseAdminUserIds trims values and drops empties", () => {
+    const parsed = parseAdminUserIds([" @a:example.org ", "", "@b:example.org", 123]);
+    expect(parsed).toEqual(new Set(["@a:example.org", "@b:example.org"]));
+  });
+
+  test("parseAgentApiTokens merges env and config tokens", () => {
+    const previousSingle = process.env.AGENT_API_TOKEN;
+    const previousMulti = process.env.AGENT_API_TOKENS;
+    process.env.AGENT_API_TOKEN = "env-single";
+    process.env.AGENT_API_TOKENS = "env-a, env-b";
+
+    try {
+      const tokens = parseAgentApiTokens({
+        ...BASE_CONFIG,
+        agentApiToken: "cfg-single",
+        agentApiTokens: ["cfg-a", "cfg-b"],
+      });
+
+      expect(tokens).toEqual(
+        new Set(["env-single", "env-a", "env-b", "cfg-single", "cfg-a", "cfg-b"]),
+      );
+    } finally {
+      if (previousSingle === undefined) {
+        delete process.env.AGENT_API_TOKEN;
+      } else {
+        process.env.AGENT_API_TOKEN = previousSingle;
+      }
+
+      if (previousMulti === undefined) {
+        delete process.env.AGENT_API_TOKENS;
+      } else {
+        process.env.AGENT_API_TOKENS = previousMulti;
+      }
+    }
+  });
+
+  test("buildRoomToProjectMap keeps first duplicate and emits callback", () => {
+    const duplicates: string[] = [];
+    const map = buildRoomToProjectMap(
+      {
+        alpha: { roomId: "!same:example.org" },
+        beta: { roomId: "!same:example.org" },
+      },
+      ({ projectKey, previousProjectKey }) => {
+        duplicates.push(`${projectKey}->${previousProjectKey}`);
+      },
+    );
+
+    expect(map.get("!same:example.org")).toBe("alpha");
+    expect(duplicates).toEqual(["beta->alpha"]);
+  });
+
+  test("resolveProject validates project existence and roomId", () => {
+    expect(() => resolveProject({}, "missing")).toThrow("unknown project: missing");
+    expect(() => resolveProject({ bad: { roomId: "" } }, "bad")).toThrow(
+      'project "bad" has no roomId',
+    );
+  });
+});

--- a/src/runtime/process.test.ts
+++ b/src/runtime/process.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { isOpenCodeRunCommand, runCommandWithInput } from "./process";
+
+describe("runtime/process", () => {
+  test("detects OpenCode run invocations", () => {
+    expect(isOpenCodeRunCommand(["opencode", "run"])).toBe(true);
+    expect(isOpenCodeRunCommand(["/usr/local/bin/opencode", "r"])).toBe(true);
+    expect(isOpenCodeRunCommand(["opencode", "models"])).toBe(false);
+  });
+
+  test("runCommandWithInput returns stdout on success", async () => {
+    const result = await runCommandWithInput(
+      ["bun", "-e", "const data = await Bun.stdin.text(); process.stdout.write(data.toUpperCase());"],
+      process.cwd(),
+      "hello",
+      1000,
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("HELLO");
+    expect(result.timedOut).toBe(false);
+  });
+
+  test("runCommandWithInput marks timeout paths", async () => {
+    const result = await runCommandWithInput(
+      ["bun", "-e", "setTimeout(() => process.stdout.write('late'), 250);"],
+      process.cwd(),
+      "",
+      25,
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.code).not.toBe(0);
+  });
+
+  test("runCommandWithInput rejects invalid executables", async () => {
+    await expect(
+      runCommandWithInput(["definitely-not-a-real-executable"], process.cwd(), "", 1000),
+    ).rejects.toThrow();
+  });
+});

--- a/src/runtime/redis.test.ts
+++ b/src/runtime/redis.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { parseEnvelope, resolveRedisConfig } from "./redis";
+import { TEST_PROJECT_KEY, TEST_ROOM_ID, buildQueueEnvelope } from "../test/fixtures";
+
+describe("runtime/redis", () => {
+  test("resolveRedisConfig uses URL defaults", () => {
+    const config = resolveRedisConfig({
+      redisUrl: "redis://localhost:6380/2",
+    });
+
+    expect(config.host).toBe("localhost");
+    expect(config.port).toBe(6380);
+    expect(config.db).toBe(2);
+  });
+
+  test("parseEnvelope supports legacy raw string payloads", () => {
+    const envelope = parseEnvelope("legacy message", TEST_PROJECT_KEY, TEST_ROOM_ID);
+
+    expect(envelope.projectKey).toBe(TEST_PROJECT_KEY);
+    expect(envelope.roomId).toBe(TEST_ROOM_ID);
+    expect(envelope.body).toBe("legacy message");
+    expect(envelope.format).toBe("markdown");
+  });
+
+  test("parseEnvelope parses structured payload contracts", () => {
+    const raw = JSON.stringify(
+      buildQueueEnvelope({
+        id: "evt-2",
+        body: "structured",
+        format: "plain",
+        sender: "@admin:example.org",
+        agent: "opencode",
+      }),
+    );
+
+    const envelope = parseEnvelope(raw, TEST_PROJECT_KEY, TEST_ROOM_ID);
+    expect(envelope).toMatchObject({
+      id: "evt-2",
+      projectKey: TEST_PROJECT_KEY,
+      roomId: TEST_ROOM_ID,
+      body: "structured",
+      format: "plain",
+      sender: "@admin:example.org",
+      agent: "opencode",
+    });
+  });
+
+  test("parseEnvelope rejects payloads without body", () => {
+    expect(() => parseEnvelope(JSON.stringify({ id: "evt-3" }), TEST_PROJECT_KEY, TEST_ROOM_ID)).toThrow(
+      "queue payload has no message body",
+    );
+  });
+});

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,16 @@
+import { type QueueEnvelope } from "../runtime/redis";
+
+export const TEST_PROJECT_KEY = "project-a";
+export const TEST_ROOM_ID = "!room-a:example.org";
+
+export function buildQueueEnvelope(overrides: Partial<QueueEnvelope> = {}): QueueEnvelope {
+  return {
+    id: "evt-1",
+    projectKey: TEST_PROJECT_KEY,
+    roomId: TEST_ROOM_ID,
+    body: "hello",
+    format: "markdown",
+    receivedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Added new test coverage for config parsing/validation (`src/runtime/config.test.ts`).
- Added command routing coverage for management commands (`src/commands/management.test.ts`).
- Added queue envelope contract coverage and Redis config defaults coverage (`src/runtime/redis.test.ts`).
- Added process execution happy/failure-path tests for command execution boundaries (`src/runtime/process.test.ts`).
- Added reusable test fixtures in `src/test/fixtures.ts` used by queue contract tests.

## Why
Issue #11 calls for stronger confidence around core behavior boundaries. These tests target config defaults/validation, command parsing/routing, queue contracts, and execution-path behavior.

## Risk / Rollback
- Low risk: test-only changes.
- Rollback by reverting this PR.

## Verification
- `bun test` (now runs 27 tests across 8 files)
- `bunx tsc --noEmit`

Closes #11